### PR TITLE
disable changelog check as slowroll does not follow it

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,8 @@ Yast::Tasks.configuration do |conf|
   conf.exclude_files << /README.md/ #do not pack readme
 end
 
+Rake::Task["osc:sr"].prerequisites.delete("check:changelog")
+
 # this package uses the date versioning in master (for openSUSE Tumbleweed),
 # replace the standard yast task implementation
 Rake::Task[:'version:bump'].clear

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ Yast::Tasks.configuration do |conf|
   conf.exclude_files << /README.md/ #do not pack readme
 end
 
+# Slowroll does not require ID for each change, so this check is unnecessary
 Rake::Task["osc:sr"].prerequisites.delete("check:changelog")
 
 # this package uses the date versioning in master (for openSUSE Tumbleweed),


### PR DESCRIPTION
## Problem

Slowroll does not require to have bsc or jira entry for each change so check that requires it in CI unnecessary blocks submission.


## Solution

Disable `check:changelog` for sending submit requests.